### PR TITLE
Enabling links in Medium block

### DIFF
--- a/src/components/LandingPageBlocks/MediumBlock/MediumBlock.css
+++ b/src/components/LandingPageBlocks/MediumBlock/MediumBlock.css
@@ -13,6 +13,9 @@
   justify-content: space-between;
   margin-bottom: 40px;
 }
+.MB-Section .MB-content .article-block a:visited {
+  text-decoration: none;
+}
 @media screen and (max-width: 1000px) {
   .MB-Section .MB-content .article-block {
     -webkit-box-orient: vertical;

--- a/src/components/LandingPageBlocks/MediumBlock/MediumBlock.js
+++ b/src/components/LandingPageBlocks/MediumBlock/MediumBlock.js
@@ -13,8 +13,8 @@ const MediumBlock = (props) => {
 			<content className="MB-content">
 				<h2>Our Medium Blog</h2>
 
-				<a target="_blank" href="https://medium.com/@isid.home/five-killer-mistakes-of-software-developers-and-how-to-avoid-them-f65e8e44c887" className="article-block">
-					<a className="article-card fiveKiller">
+				<div className="article-block">
+					<a target="_blank" href="https://medium.com/@isid.home/five-killer-mistakes-of-software-developers-and-how-to-avoid-them-f65e8e44c887" className="article-card fiveKiller">
 						<div className="article-image">
 							<img src={alcohol} alt="" />
 						</div>

--- a/src/components/LandingPageBlocks/MediumBlock/MediumBlock.less
+++ b/src/components/LandingPageBlocks/MediumBlock/MediumBlock.less
@@ -18,7 +18,6 @@
 			
 			a:visited {
 			    text-decoration: none; 
-			    decoration: none; 
 			}
 
 			@media screen and (max-width: 1000px) {


### PR DESCRIPTION
## Why do we need this change

This change is more of a fix - adding links two [Medium articles](https://medium.com/@isid.home) in MediumBlock. It doesn't make any sense to have them there just as a text.

## What changed

Changing article containers to use `a` tag instead of `div` to enable links to the medium blog. Also changing corresponding styles not to have ambiguous coloring for the whole block.