### PR TITLE
set mobile background farther to the right, so it wont throw shadow o…

### DIFF
--- a/src/components/NavigationBar/mobileNavigation/mobileNavigation.js
+++ b/src/components/NavigationBar/mobileNavigation/mobileNavigation.js
@@ -38,7 +38,7 @@ const MobileNavigation = (props) => {
 
 			<div className="mobile-navigation_background"
                 style={{
-					right: props.display ? "0" : "-75vw"
+					right: props.display ? "0" : "-85vw"
 				}}
             >
 				<a  onClick={props.toggle} href="#services-block_anchor">What we do</a>


### PR DESCRIPTION
## About this PR
small fix on mobile navigation background positioning, set it farther to the right so we can't see its shadow when mobile nav is hidden.